### PR TITLE
fix(metrics): tolerate GitHub API failures in get_latest_release

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -15,15 +15,19 @@ prometheus_client.REGISTRY.unregister(prometheus_client.PROCESS_COLLECTOR)
 
 
 def get_latest_release(name):
-    if name == 'bor':
-        url = 'https://api.github.com/repos/maticnetwork/bor/releases/latest'
-    else:
-        return False
-    data = requests.get(url).json()
-    version = data["tag_name"].split('v')[1]
-    info = { key:data[key] for key in ["name", "tag_name", "published_at"] }
-    info['version'] = version
-    return info
+    try:
+        if name == 'bor':
+            url = 'https://api.github.com/repos/maticnetwork/bor/releases/latest'
+        else:
+            return False
+        data = requests.get(url, timeout=10).json()
+        version = data["tag_name"].split('v')[1]
+        info = { key:data[key] for key in ["name", "tag_name", "published_at"] }
+        info['version'] = version
+        return info
+    except Exception as e:
+        import logging; logging.warning('get_latest_release(%s) failed: %s', name, e)
+        return {'name': 'unknown', 'tag_name': 'v0.0.0', 'published_at': '', 'version': '0.0.0'}
 
 def get_all_metrics():
     w3 = Web3(HTTPProvider(config["FULLNODE_URL"], request_kwargs={'timeout': int(config['FULLNODE_TIMEOUT'])}))


### PR DESCRIPTION
get_latest_release() is called at module import time via prometheus_client labels in app/api/metrics.py. When GitHub's unauthenticated API returns 403 (rate-limit) or any other non-2xx, the response body does not contain 'tag_name', so the unconditional data['tag_name'].split('v')[1] raises KeyError. Because the call sits at import time, the Flask blueprint fails to register and the container goes into CrashLoopBackOff.

Harden the helper:
- request timeout (10s) so a slow/hung GitHub call cannot wedge worker startup,
- catch any exception, log a warning, and return a placeholder version dict so the metrics blueprint still imports cleanly,
- preserve existing behavior on the happy path.

Observed in production: GitHub rate-limited the cluster's IP and all four EVM coin backends (eth/bnb/polygon/avalanche) crashed in parallel.